### PR TITLE
Add automatic release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,6 +2,7 @@ changelog:
   exclude:
     labels:
       - ignore-for-release
+      - ignore
   categories:
     - title: Breaking Changes 🛠
       labels:

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,20 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - major
+        - breaking-change
+        - breaking
+    - title: Exciting New Features 🎉
+      labels:
+        - minor
+        - enhancement
+        - feature
+    - title: Bug Fixes 🐛
+      labels:
+        - patch
+        - bug
+        - bugfix

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -1,0 +1,54 @@
+name: Pull Request Validation
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - labeled
+      - unlabeled
+      - ready_for_review
+      - reopened
+
+jobs:
+  basic-pr-validation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if PR has a valid release label
+        uses: actions/github-script@v6         
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const validLabels = [
+              "major",
+              "breaking",
+              "breaking-change",
+              "minor",
+              "feature",
+              "enhancement",
+              "patch",
+              "bugfix",
+              "bug",
+              "ignore-for-release",
+              "ignore"
+            ]
+            const labels = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number
+            });
+            const labelNames = labels.data.map(label => label.name);
+            const matchingLabels = labelNames.filter(label => validLabels.includes(label));
+            if (matchingLabels && matchingLabels.length > 1) {
+              core.setFailed(`PR has more than one release label. You must only assign one of ${matchingLabels.join(", ")}`);
+              return
+            }
+            if (matchingLabels && matchingLabels.length === 0) {
+              core.setFailed(`PR has no release label, Valid labels are: ${validLabels.join(", ")}`);
+              return
+            }
+            if (matchingLabels && matchingLabels.length === 1) {
+              core.setOutput("success", "PR has a valid release label");
+              return
+            }
+            core.setFailed("Something went wrong")


### PR DESCRIPTION
Fixes: https://github.com/mkah91/azure-keyvault-cli/issues/12

This pr adds the automatic release note by adding the `.github/release.yml` file.
Thereby have a look in the file and check if the content matches your expectations!

It also adds a validation, that pr's must have a release label assigned.
The check runs if a pr is set ready_for_review, reopened or the labels are changed.
It will fail if there is no or more than one release label assigned.